### PR TITLE
Use time_t as type for time()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -273,8 +273,8 @@ void signal_act(int sig)
     fprintf(ftty, "Interrupt\n");
     if (ftty != stderr)  fprintf(stderr, "*** Interrupt\n");
 
-    static long last_sigint_time = 0;
-    long curtime;
+    static time_t last_sigint_time = 0;
+    time_t curtime;
     time(&curtime);
     bool isInsisted = (curtime - last_sigint_time <= 2); // re-pressed Ctrl-C after less than 2 secs
     if (!isInsisted && qApp != NULL) {


### PR DESCRIPTION
The return type of `time()` is `time_t`, so use it instead of `long`.

While `time_t` is generally the same as `long`, in some cases it is not, e.g. on 32 bit architectures supporting 64 bit timestamps.